### PR TITLE
Add option to require all taxonomies match

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -38,19 +38,17 @@ function crpt_save_options( $crp_settings, $postvariable ) {
 		'public'   => true,
 		'_builtin' => false,
 	);
+
 	$output = 'names'; // or objects
 	$operator = 'and'; // 'and' or 'or'
 	$wp_taxonomies = get_taxonomies( $args, $output, $operator );
 
 	/* Save options for custom taxonomies */
 	$taxonomies = ( isset( $postvariable['crpt_taxes'] ) && is_array( $postvariable['crpt_taxes'] ) ) ? $postvariable['crpt_taxes'] : array();
-
 	$taxonomies = array_intersect( $wp_taxonomies, $taxonomies );
 
 	$crp_settings['crpt_taxes'] = implode( ",", $taxonomies );
-
-
-	/* Disable Contextual Matching */
+	$crp_settings['crpt_match_all'] = isset( $postvariable['crpt_match_all'] ) ? true : false;
 	$crp_settings['crpt_disable_contextual'] = ( isset( $postvariable['crpt_disable_contextual'] ) ? true : false );
 	$crp_settings['crpt_disable_contextual_cpt'] = ( isset( $postvariable['crpt_disable_contextual_cpt'] ) ? true : false );
 
@@ -74,14 +72,17 @@ function crt_general_options( $crp_settings ) {
 		'public'   => true,
 		'_builtin' => false,
 	);
+
 	$output = 'names'; // or objects
 	$operator = 'and'; // 'and' or 'or'
 	$wp_taxonomies = get_taxonomies( $args, $output, $operator );
 
 	$taxonomies = isset( $crp_settings['crpt_taxes'] ) ? explode( ",", $crp_settings['crpt_taxes'] ) : array();
-
 	$taxonomies = array_intersect( $taxonomies, $wp_taxonomies );
 
+	if ( !isset( $crp_settings['crpt_match_all'] ) ) {
+		$crp_settings['crpt_match_all'] = 'OR';
+	}
 ?>
 
 	<tr><th scope="row"><?php _e( 'Fetch related posts only from:', 'crp-taxonomy' ); ?></th>
@@ -95,7 +96,14 @@ function crt_general_options( $crp_settings ) {
 
 			<?php endforeach; endif; ?>
 
-			<p class="description"><?php _e( "Limit the related posts only to the current categories, tags and/or custom post types", 'crp-taxonomy' ); ?></p>
+			<p class="description"><?php _e( "Limit the related posts only to the current categories, tags, and/or taxonomies.", 'crp-taxonomy' ); ?></p>
+		</td>
+	</tr>
+
+	<tr><th scope="row"><?php _e( 'Taxonomy matching:', 'crp-taxonomy' ); ?></th>
+		<td>
+			<label><input type="checkbox" name="crpt_match_all" id="crpt_match_all" <?php if ( $crp_settings['crpt_match_all'] ) echo 'checked="checked"' ?> /> <?php _e( 'Match all taxonomy terms', 'crp-taxonomy' ); ?></label><br />
+			<p class="description"><?php _e( 'If selected, will limit the related posts to ones that match all the taxonomy terms of the current post (for the above selected taxonomies) instead of just one of them.', 'crp-taxonomy' ); ?></p>
 		</td>
 	</tr>
 

--- a/crp-taxonomy.php
+++ b/crp-taxonomy.php
@@ -125,6 +125,7 @@ function crpt_crp_posts_where( $where ) {
 			// the data into a string and matching against that.  Now this does return nearly the same results
 			// as if crpt_match_all was false, however a HAVING statement added later reduces the dataset down
 			// to only posts that match ALL the taxonomies.
+			// Credit for solution: http://wordpress.stackexchange.com/questions/8503/optimize-multiple-taxonomy-term-mysql-query
 			$sql .= "AND CONCAT($wpdb->term_taxonomy.taxonomy, '/', $wpdb->terms.term_id) IN (\n";
 			$sql .= implode( ",\n", $term_strings );
 			$sql .= "\n)";


### PR DESCRIPTION
- Added a new option to require the related posts to match a term in each of the current taxonomies.
- The way it worked before was basically just an OR, it would find a match for the current category or tag or taxonomies, but couldn't require a match of all at the same time.  The option changes that into an AND.
- Fixed some white space issue (mixed tabs & spaces)
